### PR TITLE
Improve errors by making public vars which are the actual error instance

### DIFF
--- a/authMiddleware/tokenAuth.go
+++ b/authMiddleware/tokenAuth.go
@@ -15,13 +15,14 @@ import (
 // TODO:  tests for this middleware like at https://medium.com/@PurdonKyle/unit-testing-golang-http-middleware-c7727ca896ea
 // Eventually this will be configurable.
 const DefaultUserKey string = "user"
+var UserNotInContextError = errors.New("Could not get worrywort.User from context")
 
 // Type safe function to get user from context
 func UserFromContext(ctx context.Context) (worrywort.User, error) {
 	u, ok := ctx.Value(DefaultUserKey).(worrywort.User)
 	if !ok {
 		// can this differentiate between missing key and invalid value?
-		return worrywort.User{}, errors.New("Could not get worrywort.User from context")
+		return worrywort.User{}, UserNotInContextError
 	}
 	return u, nil
 }

--- a/worrywort/authToken.go
+++ b/worrywort/authToken.go
@@ -12,7 +12,7 @@ import (
 
 var InvalidTokenError error = errors.New("Invalid token. Not found.")
 
-const TokenFormatError = "Token should be formatted as `tokenId:secret` but was not"
+var TokenFormatError = errors.New("Token should be formatted as `tokenId:secret` but was not")
 
 // TODO: Possibly move authToken stuff to its own package so that scope stuff will be
 // authToken.READ_ALL, etc.

--- a/worrywort/user.go
+++ b/worrywort/user.go
@@ -171,7 +171,7 @@ func LookupUserByToken(tokenStr string, db *sqlx.DB) (User, error) {
 	// for explicitness that token is passed in has 2 parts
 	tokenParts := strings.SplitN(tokenStr, ":", 2)
 	if len(tokenParts) != 2 {
-		return User{}, errors.New(TokenFormatError) // should return an error about invalid token probably
+		return User{}, TokenFormatError
 	}
 
 	tokenId := tokenParts[0]


### PR DESCRIPTION
rather than just making the string message public.