### PR TITLE
Removing the immutable object/struct stuff

### DIFF
--- a/authMiddleware/tokenAuth.go
+++ b/authMiddleware/tokenAuth.go
@@ -15,6 +15,7 @@ import (
 // TODO:  tests for this middleware like at https://medium.com/@PurdonKyle/unit-testing-golang-http-middleware-c7727ca896ea
 // Eventually this will be configurable.
 const DefaultUserKey string = "user"
+
 var UserNotInContextError = errors.New("Could not get worrywort.User from context")
 
 // Type safe function to get user from context

--- a/graphqlApi/graphql_test.go
+++ b/graphqlApi/graphql_test.go
@@ -117,7 +117,7 @@ func TestLoginMutation(t *testing.T) {
 			t.Errorf("Expected auth token with id %s to be saved to database", tokenId)
 		}
 
-		if newToken.User().ID() != user.ID() {
+		if newToken.User.ID != user.ID {
 			t.Errorf("Expected auth token to be associated with user %v but it is associated with %v", user, newToken.User)
 		}
 	})
@@ -182,7 +182,7 @@ func TestBatchQuery(t *testing.T) {
 
 	t.Run("Test query for batch(id: ID!) which exists returns the batch", func(t *testing.T) {
 		variables := map[string]interface{}{
-			"id": strconv.Itoa(b.ID()),
+			"id": strconv.Itoa(b.ID),
 		}
 		query := `
 			query getBatch($id: ID!) {
@@ -198,7 +198,7 @@ func TestBatchQuery(t *testing.T) {
 		result := worrywortSchema.Exec(ctx, query, operationName, variables)
 
 		var expected interface{}
-		err := json.Unmarshal([]byte(fmt.Sprintf(`{"batch": {"__typename": "Batch", "id": "%d"}}`, b.ID())), &expected)
+		err := json.Unmarshal([]byte(fmt.Sprintf(`{"batch": {"__typename": "Batch", "id": "%d"}}`, b.ID)), &expected)
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
@@ -252,7 +252,7 @@ func TestBatchQuery(t *testing.T) {
 
 		var expected interface{}
 		err := json.Unmarshal(
-			[]byte(fmt.Sprintf(`{"batches":[{"__typename":"Batch","id":"%d"},{"__typename":"Batch","id":"%d"}]}`, b.ID(), b2.ID())),
+			[]byte(fmt.Sprintf(`{"batches":[{"__typename":"Batch","id":"%d"},{"__typename":"Batch","id":"%d"}]}`, b.ID, b2.ID)),
 			&expected)
 		if err != nil {
 			t.Fatalf("%v", err)

--- a/graphqlApi/resolvers.go
+++ b/graphqlApi/resolvers.go
@@ -54,7 +54,7 @@ func (r *Resolver) Batch(ctx context.Context, args struct{ ID graphql.ID }) (*ba
 	var err error
 	batchArgs := make(map[string]interface{})
 	// TODO: Or if batch is publicly readable by anyone?
-	batchArgs["created_by_user_id"] = u.ID()
+	batchArgs["created_by_user_id"] = u.ID
 	batchArgs["id"], err = strconv.ParseInt(string(args.ID), 10, 0)
 
 	if err != nil {
@@ -138,29 +138,31 @@ type userResolver struct {
 	u worrywort.User
 }
 
-func (r *userResolver) ID() graphql.ID    { return graphql.ID(strconv.Itoa(r.u.ID())) }
-func (r *userResolver) FirstName() string { return r.u.FirstName() }
-func (r *userResolver) LastName() string  { return r.u.LastName() }
-func (r *userResolver) Email() string     { return r.u.Email() }
-func (r *userResolver) CreatedAt() string { return dateString(r.u.CreatedAt()) }
-func (r *userResolver) UpdatedAt() string { return dateString(r.u.UpdatedAt()) }
+func (r *userResolver) ID() graphql.ID    { return graphql.ID(strconv.Itoa(r.u.ID)) }
+func (r *userResolver) FirstName() string { return r.u.FirstName }
+func (r *userResolver) LastName() string  { return r.u.LastName }
+func (r *userResolver) Email() string     { return r.u.Email }
+func (r *userResolver) CreatedAt() string { return dateString(r.u.CreatedAt) }
+func (r *userResolver) UpdatedAt() string { return dateString(r.u.UpdatedAt) }
 
 type batchResolver struct {
 	b worrywort.Batch
 }
 
-func (r *batchResolver) ID() graphql.ID       { return graphql.ID(strconv.Itoa(r.b.ID())) }
-func (r *batchResolver) Name() string         { return r.b.Name() }
-func (r *batchResolver) BrewNotes() string    { return r.b.BrewNotes() }
-func (r *batchResolver) TastingNotes() string { return r.b.TastingNotes() }
+func (r *batchResolver) ID() graphql.ID       { return graphql.ID(strconv.Itoa(r.b.ID)) }
+func (r *batchResolver) Name() string         { return r.b.Name }
+func (r *batchResolver) BrewNotes() string    { return r.b.BrewNotes }
+func (r *batchResolver) TastingNotes() string { return r.b.TastingNotes }
 
 // TODO: I should make an actual DateTime type which can be null or a valid datetime string
-func (r *batchResolver) BrewedDate() *string  { return nullableDateString(r.b.BrewedDate()) }
-func (r *batchResolver) BottledDate() *string { return nullableDateString(r.b.BottledDate()) }
+func (r *batchResolver) BrewedDate() *string  { return nullableDateString(r.b.BrewedDate) }
+func (r *batchResolver) BottledDate() *string { return nullableDateString(r.b.BottledDate) }
 func (r *batchResolver) VolumeBoiled() *float64 {
 	// If the value is optional/nullable in the GraphQL schema then we must return a pointer
 	// to it.
-	vol := r.b.VolumeBoiled()
+	// TODO: I do not like this.  Maybe switch the data type to https://godoc.org/gopkg.in/guregu/null.v3 nullint
+	// on the struct
+	vol := r.b.VolumeBoiled
 	if vol == 0 {
 		return nil
 	}
@@ -168,17 +170,21 @@ func (r *batchResolver) VolumeBoiled() *float64 {
 }
 
 func (r *batchResolver) VolumeInFermenter() *float64 {
-	vol := r.b.VolumeInFermenter()
+	vol := r.b.VolumeInFermenter
+
+	// TODO: I do not like this.  Maybe switch the data type to https://godoc.org/gopkg.in/guregu/null.v3 nullint
+	// on the struct
 	if vol == 0 {
 		return nil
 	}
 	return &vol
 }
 
-func (r *batchResolver) VolumeUnits() worrywort.VolumeUnitType { return r.b.VolumeUnits() }
+func (r *batchResolver) VolumeUnits() worrywort.VolumeUnitType { return r.b.VolumeUnits }
 func (r *batchResolver) OriginalGravity() *float64 {
-	// TODO: not sure I like this... maybe it really was 0.  Not likely with OG, of course.
-	og := r.b.OriginalGravity()
+	// TODO: I do not like this.  Maybe switch the data type to https://godoc.org/gopkg.in/guregu/null.v3 nullint
+	// on the struct
+	og := r.b.OriginalGravity
 	if og == 0 {
 		return nil
 	}
@@ -186,43 +192,48 @@ func (r *batchResolver) OriginalGravity() *float64 {
 }
 
 func (r *batchResolver) FinalGravity() *float64 {
-	fg := r.b.FinalGravity()
+	fg := r.b.FinalGravity
+
+	// TODO: I do not like this.  Maybe switch the data type to https://godoc.org/gopkg.in/guregu/null.v3 nullint
+	// on the struct
 	if fg == 0 {
 		return nil
 	}
 	return &fg
 }
 
-func (r *batchResolver) RecipeURL() string { return r.b.RecipeURL() } // this could even return a parsed URL object...
-func (r *batchResolver) CreatedAt() string { return dateString(r.b.CreatedAt()) }
-func (r *batchResolver) UpdatedAt() string { return dateString(r.b.UpdatedAt()) }
+func (r *batchResolver) RecipeURL() string { return r.b.RecipeURL } // this could even return a parsed URL object...
+func (r *batchResolver) CreatedAt() string { return dateString(r.b.CreatedAt) }
+func (r *batchResolver) UpdatedAt() string { return dateString(r.b.UpdatedAt) }
 
 // TODO: Make this return an actual nil if there is no createdBy, such as for a deleted user?
-func (r *batchResolver) CreatedBy() *userResolver { return &userResolver{u: r.b.CreatedBy()} }
+func (r *batchResolver) CreatedBy() *userResolver { return &userResolver{u: r.b.CreatedBy} }
 
 // Resolve a worrywort.Fermenter
 type fermenterResolver struct {
 	f worrywort.Fermenter
 }
 
-func (r *fermenterResolver) ID() graphql.ID    { return graphql.ID(strconv.Itoa(r.f.ID())) }
-func (r *fermenterResolver) CreatedAt() string { return dateString(r.f.CreatedAt()) }
-func (r *fermenterResolver) UpdatedAt() string { return dateString(r.f.UpdatedAt()) }
+func (r *fermenterResolver) ID() graphql.ID    { return graphql.ID(strconv.Itoa(r.f.ID)) }
+func (r *fermenterResolver) CreatedAt() string { return dateString(r.f.CreatedAt) }
+func (r *fermenterResolver) UpdatedAt() string { return dateString(r.f.UpdatedAt) }
 
 // TODO: Make this return an actual nil if there is no createdBy, such as for a deleted user?
-func (r *fermenterResolver) CreatedBy() *userResolver { return &userResolver{u: r.f.CreatedBy()} }
+func (r *fermenterResolver) CreatedBy() *userResolver { return &userResolver{u: r.f.CreatedBy} }
 
 // Resolve a worrywort.TemperatureSensor
 type temperatureSensorResolver struct {
 	t worrywort.TemperatureSensor
 }
 
-func (r *temperatureSensorResolver) ID() graphql.ID    { return graphql.ID(strconv.Itoa(r.t.ID())) }
-func (r *temperatureSensorResolver) CreatedAt() string { return dateString(r.t.CreatedAt()) }
-func (r *temperatureSensorResolver) UpdatedAt() string { return dateString(r.t.UpdatedAt()) }
+func (r *temperatureSensorResolver) ID() graphql.ID    { return graphql.ID(strconv.Itoa(r.t.ID)) }
+func (r *temperatureSensorResolver) CreatedAt() string { return dateString(r.t.CreatedAt) }
+func (r *temperatureSensorResolver) UpdatedAt() string { return dateString(r.t.UpdatedAt) }
 
 // TODO: Make this return an actual nil if there is no createdBy, such as for a deleted user?
-func (r *temperatureSensorResolver) CreatedBy() *userResolver { return &userResolver{u: r.t.CreatedBy()} }
+func (r *temperatureSensorResolver) CreatedBy() *userResolver {
+	return &userResolver{u: r.t.CreatedBy}
+}
 
 // Resolve a worrywort.TemperatureMeasurement
 type temperatureMeasurementResolver struct {
@@ -230,13 +241,13 @@ type temperatureMeasurementResolver struct {
 	m worrywort.TemperatureMeasurement
 }
 
-func (r *temperatureMeasurementResolver) ID() graphql.ID    { return graphql.ID(r.m.ID()) }
-func (r *temperatureMeasurementResolver) CreatedAt() string { return dateString(r.m.CreatedAt()) }
-func (r *temperatureMeasurementResolver) UpdatedAt() string { return dateString(r.m.UpdatedAt()) }
+func (r *temperatureMeasurementResolver) ID() graphql.ID    { return graphql.ID(r.m.ID) }
+func (r *temperatureMeasurementResolver) CreatedAt() string { return dateString(r.m.CreatedAt) }
+func (r *temperatureMeasurementResolver) UpdatedAt() string { return dateString(r.m.UpdatedAt) }
 
 // TODO: Make this return an actual nil if there is no createdBy, such as for a deleted user?
 func (r *temperatureMeasurementResolver) CreatedBy() *userResolver {
-	return &userResolver{u: r.m.CreatedBy()}
+	return &userResolver{u: r.m.CreatedBy}
 }
 
 // An auth token returned after logging in to use in Authentication headers

--- a/graphqlApi/resolvers_test.go
+++ b/graphqlApi/resolvers_test.go
@@ -50,7 +50,7 @@ func TestUserResolver(t *testing.T) {
 
 	t.Run("CreatedAt()", func(t *testing.T) {
 		var dt string = r.CreatedAt()
-		expected := u.CreatedAt().Format(time.RFC3339)
+		expected := u.CreatedAt.Format(time.RFC3339)
 		if dt != expected {
 			t.Errorf("Expected: %v, got: %v", expected, dt)
 		}
@@ -58,7 +58,7 @@ func TestUserResolver(t *testing.T) {
 
 	t.Run("UpdatedAt()", func(t *testing.T) {
 		var dt string = r.UpdatedAt()
-		expected := u.UpdatedAt().Format(time.RFC3339)
+		expected := u.UpdatedAt.Format(time.RFC3339)
 		if dt != expected {
 			t.Errorf("Expected: %v, got %v", expected, dt)
 		}
@@ -110,7 +110,7 @@ func TestBatchResolver(t *testing.T) {
 
 	t.Run("BrewedDate()", func(t *testing.T) {
 		var dt *string = br.BrewedDate()
-		expected := brewed.BrewedDate().Format(time.RFC3339)
+		expected := brewed.BrewedDate.Format(time.RFC3339)
 		if *dt != expected {
 			t.Errorf("Expected: %v, got: %v", expected, dt)
 		}
@@ -123,7 +123,7 @@ func TestBatchResolver(t *testing.T) {
 
 	t.Run("BottledDate()", func(t *testing.T) {
 		var dt *string = br.BottledDate()
-		expected := brewed.BottledDate().Format(time.RFC3339)
+		expected := brewed.BottledDate.Format(time.RFC3339)
 		if *dt != expected {
 			t.Errorf("Expected: %v, got: %v", expected, dt)
 		}
@@ -136,7 +136,7 @@ func TestBatchResolver(t *testing.T) {
 
 	t.Run("CreatedAt()", func(t *testing.T) {
 		var dt string = br.CreatedAt()
-		expected := brewed.CreatedAt().Format(time.RFC3339)
+		expected := brewed.CreatedAt.Format(time.RFC3339)
 		if dt != expected {
 			t.Errorf("Expected: %v, got: %v", expected, dt)
 		}
@@ -144,7 +144,7 @@ func TestBatchResolver(t *testing.T) {
 
 	t.Run("UpdatedAt()", func(t *testing.T) {
 		var dt string = br.UpdatedAt()
-		expected := brewed.UpdatedAt().Format(time.RFC3339)
+		expected := brewed.UpdatedAt.Format(time.RFC3339)
 		if dt != expected {
 			t.Errorf("Expected: %v, got %v", expected, dt)
 		}
@@ -152,7 +152,7 @@ func TestBatchResolver(t *testing.T) {
 
 	t.Run("VolumeBoiled()", func(t *testing.T) {
 		var actual *float64 = br.VolumeBoiled()
-		expected := brewed.VolumeBoiled()
+		expected := brewed.VolumeBoiled
 		// direct comparison seems to be ok, probably since no math is happening
 		// but may be better to do like this:
 		// if math.Abs(*boiled - expected) > .0000000001 {
@@ -163,7 +163,7 @@ func TestBatchResolver(t *testing.T) {
 
 	t.Run("VolumeInFermenter()", func(t *testing.T) {
 		var actual *float64 = br.VolumeInFermenter()
-		expected := brewed.VolumeInFermenter()
+		expected := brewed.VolumeInFermenter
 		// direct comparison seems to be ok, probably since no math is happening
 		// but may be better to do like this:
 		// if math.Abs(*boiled - expected) > .0000000001 {
@@ -174,7 +174,7 @@ func TestBatchResolver(t *testing.T) {
 
 	t.Run("OriginalGravity()", func(t *testing.T) {
 		var actual *float64 = br.OriginalGravity()
-		expected := brewed.OriginalGravity()
+		expected := brewed.OriginalGravity
 		// direct comparison seems to be ok, probably since no math is happening
 		// but may be better to do like this:
 		// if math.Abs(*boiled - expected) > .0000000001 {
@@ -185,7 +185,7 @@ func TestBatchResolver(t *testing.T) {
 
 	t.Run("FinalGravity()", func(t *testing.T) {
 		var actual *float64 = br.FinalGravity()
-		expected := brewed.FinalGravity()
+		expected := brewed.FinalGravity
 		// direct comparison seems to be ok, probably since no math is happening
 		// but may be better to do like this:
 		// if math.Abs(*boiled - expected) > .0000000001 {
@@ -196,7 +196,7 @@ func TestBatchResolver(t *testing.T) {
 
 	t.Run("VolumeUnits()", func(t *testing.T) {
 		var actual worrywort.VolumeUnitType = br.VolumeUnits()
-		expected := brewed.VolumeUnits()
+		expected := brewed.VolumeUnits
 
 		if actual != expected {
 			t.Errorf("Expected: %v, got %v", expected, actual)
@@ -205,7 +205,7 @@ func TestBatchResolver(t *testing.T) {
 
 	t.Run("RecipeURL()", func(t *testing.T) {
 		var actual string = br.RecipeURL()
-		expected := brewed.RecipeURL()
+		expected := brewed.RecipeURL
 
 		if actual != expected {
 			t.Errorf("Expected: %v, got %v", expected, actual)
@@ -214,7 +214,7 @@ func TestBatchResolver(t *testing.T) {
 
 	t.Run("CreatedBy()", func(t *testing.T) {
 		var actual *userResolver = br.CreatedBy()
-		expected := userResolver{u: brewed.CreatedBy()}
+		expected := userResolver{u: brewed.CreatedBy}
 		if *actual != expected {
 			t.Errorf("Expected: %v, got %v", expected, actual)
 		}
@@ -237,7 +237,7 @@ func TestFermenterResolver(t *testing.T) {
 
 	t.Run("CreatedAt()", func(t *testing.T) {
 		var dt string = r.CreatedAt()
-		expected := f.CreatedAt().Format(time.RFC3339)
+		expected := f.CreatedAt.Format(time.RFC3339)
 		if dt != expected {
 			t.Errorf("Expected: %v, got: %v", expected, dt)
 		}
@@ -245,7 +245,7 @@ func TestFermenterResolver(t *testing.T) {
 
 	t.Run("UpdatedAt()", func(t *testing.T) {
 		var dt string = r.UpdatedAt()
-		expected := f.UpdatedAt().Format(time.RFC3339)
+		expected := f.UpdatedAt.Format(time.RFC3339)
 		if dt != expected {
 			t.Errorf("Expected: %v, got %v", expected, dt)
 		}
@@ -253,7 +253,7 @@ func TestFermenterResolver(t *testing.T) {
 
 	t.Run("CreatedBy()", func(t *testing.T) {
 		var actual *userResolver = r.CreatedBy()
-		expected := userResolver{u: f.CreatedBy()}
+		expected := userResolver{u: f.CreatedBy}
 		if *actual != expected {
 			t.Errorf("Expected: %v, got %v", expected, actual)
 		}
@@ -275,7 +275,7 @@ func TestTemperatureSensorResolver(t *testing.T) {
 
 	t.Run("CreatedAt()", func(t *testing.T) {
 		var dt string = r.CreatedAt()
-		expected := therm.CreatedAt().Format(time.RFC3339)
+		expected := therm.CreatedAt.Format(time.RFC3339)
 		if dt != expected {
 			t.Errorf("Expected: %v, got: %v", expected, dt)
 		}
@@ -283,7 +283,7 @@ func TestTemperatureSensorResolver(t *testing.T) {
 
 	t.Run("UpdatedAt()", func(t *testing.T) {
 		var dt string = r.UpdatedAt()
-		expected := therm.UpdatedAt().Format(time.RFC3339)
+		expected := therm.UpdatedAt.Format(time.RFC3339)
 		if dt != expected {
 			t.Errorf("Expected: %v, got %v", expected, dt)
 		}
@@ -291,7 +291,7 @@ func TestTemperatureSensorResolver(t *testing.T) {
 
 	t.Run("CreatedBy()", func(t *testing.T) {
 		var actual *userResolver = r.CreatedBy()
-		expected := userResolver{u: therm.CreatedBy()}
+		expected := userResolver{u: therm.CreatedBy}
 		if *actual != expected {
 			t.Errorf("Expected: %v, got %v", expected, actual)
 		}
@@ -312,7 +312,7 @@ func TestTemperatureMeasurementResolver(t *testing.T) {
 
 	t.Run("ID()", func(t *testing.T) {
 		var ID graphql.ID = r.ID()
-		expected := graphql.ID(m.ID())
+		expected := graphql.ID(m.ID)
 		if ID != expected {
 			t.Errorf("\nExpected: %v\ngot: %v", expected, ID)
 		}
@@ -320,7 +320,7 @@ func TestTemperatureMeasurementResolver(t *testing.T) {
 
 	t.Run("CreatedAt()", func(t *testing.T) {
 		var dt string = r.CreatedAt()
-		expected := m.CreatedAt().Format(time.RFC3339)
+		expected := m.CreatedAt.Format(time.RFC3339)
 		if dt != expected {
 			t.Errorf("\nExpected: %v\ngot: %v", expected, dt)
 		}
@@ -328,7 +328,7 @@ func TestTemperatureMeasurementResolver(t *testing.T) {
 
 	t.Run("UpdatedAt()", func(t *testing.T) {
 		var dt string = r.UpdatedAt()
-		expected := m.UpdatedAt().Format(time.RFC3339)
+		expected := m.UpdatedAt.Format(time.RFC3339)
 		if dt != expected {
 			t.Errorf("\nExpected: %v\ngot %v", expected, dt)
 		}
@@ -336,7 +336,7 @@ func TestTemperatureMeasurementResolver(t *testing.T) {
 
 	t.Run("CreatedBy()", func(t *testing.T) {
 		var actual *userResolver = r.CreatedBy()
-		expected := userResolver{u: b.CreatedBy()}
+		expected := userResolver{u: m.CreatedBy}
 		if *actual != expected {
 			t.Errorf("\nExpected: %v\ngot %v", expected, actual)
 		}

--- a/worrywort/batch.go
+++ b/worrywort/batch.go
@@ -34,7 +34,7 @@ const (
 
 // Should these be exportable if I am going to use factory methods?  NewBatch() etc?
 // as long as I provide a Batcher interface or whatever?
-type batch struct {
+type Batch struct {
 	ID                 int            `db:"id"`
 	CreatedBy          User           `db:"created_by,prefix=u"`
 	Name               string         `db:"name"`
@@ -59,63 +59,38 @@ type batch struct {
 }
 
 // Returns a list of the db columns to use for a SELECT query
-func (b batch) queryColumns() []string {
+func (b Batch) queryColumns() []string {
 	// TODO: Way to dynamically build this using the `db` tag and reflection/introspection
 	return []string{"id", "name", "brew_notes", "tasting_notes", "brewed_date", "bottled_date",
 		"volume_boiled", "volume_in_fermenter", "volume_units", "original_gravity", "final_gravity", "recipe_url",
 		"max_temperature", "min_temperature", "average_temperature", "created_at", "updated_at"}
 }
 
-type Batch struct {
-	batch
-}
-
-func (b Batch) ID() int                     { return b.batch.ID }
-func (b Batch) Name() string                { return b.batch.Name }
-func (b Batch) BrewNotes() string           { return b.batch.BrewNotes }
-func (b Batch) TastingNotes() string        { return b.batch.TastingNotes }
-func (b Batch) BrewedDate() time.Time       { return b.batch.BrewedDate }
-func (b Batch) BottledDate() time.Time      { return b.batch.BottledDate }
-func (b Batch) VolumeBoiled() float64       { return b.batch.VolumeBoiled }
-func (b Batch) VolumeInFermenter() float64  { return b.batch.VolumeInFermenter }
-func (b Batch) VolumeUnits() VolumeUnitType { return b.batch.VolumeUnits }
-func (b Batch) OriginalGravity() float64    { return b.batch.OriginalGravity }
-func (b Batch) FinalGravity() float64       { return b.batch.FinalGravity }
-func (b Batch) RecipeURL() string           { return b.batch.RecipeURL } // this could even return a parsed URL object...
-func (b Batch) CreatedAt() time.Time        { return b.batch.CreatedAt }
-func (b Batch) UpdatedAt() time.Time        { return b.batch.UpdatedAt }
-func (b Batch) CreatedBy() User             { return b.batch.CreatedBy }
-func (b Batch) MaxTemperature() float64     { return b.batch.MaxTemperature }
-func (b Batch) MinTemperature() float64     { return b.batch.MinTemperature }
-func (b Batch) AverageTemperature() float64 { return b.batch.AverageTemperature }
-
-// Performs a comparison of all attributes of the Batches.  Related structs have only their ID() compared.
-// may rename to just Equal() or that may be used for a simpler ID() only type comparison, but that is easy to
+// Performs a comparison of all attributes of the Batches.  Related structs have only their ID compared.
+// may rename to just Equal() or that may be used for a simpler ID only type comparison, but that is easy to
 // compare anyway.
 func (b Batch) StrictEqual(other Batch) bool {
 	// TODO: do not follow the object for CreatedBy() to get id, but will need to add a CreatedById() to
 	// the batch struct
-	fmt.Printf("%v", b.CreatedAt())
-	fmt.Printf("%v", other.CreatedAt())
-	return b.ID() == other.ID() && b.Name() == other.Name() && b.BrewNotes() == other.BrewNotes() &&
-		b.TastingNotes() == other.TastingNotes() && b.VolumeUnits() == other.VolumeUnits() &&
-		b.VolumeInFermenter() == other.VolumeInFermenter() && b.VolumeBoiled() == other.VolumeBoiled() &&
-		b.OriginalGravity() == other.OriginalGravity() && b.FinalGravity() == other.FinalGravity() &&
-		b.RecipeURL() == other.RecipeURL() && b.CreatedBy().ID() == other.CreatedBy().ID() &&
-		b.MaxTemperature() == other.MaxTemperature() && b.MinTemperature() == other.MinTemperature() &&
-		b.AverageTemperature() == other.AverageTemperature() &&
-		b.BrewedDate().Equal(other.BrewedDate()) && b.BottledDate().Equal(other.BottledDate()) &&
-		b.CreatedAt().Equal(other.CreatedAt()) //&& b.UpdatedAt().Equal(other.UpdatedAt())
+	return b.ID == other.ID && b.Name == other.Name && b.BrewNotes == other.BrewNotes &&
+		b.TastingNotes == other.TastingNotes && b.VolumeUnits == other.VolumeUnits &&
+		b.VolumeInFermenter == other.VolumeInFermenter && b.VolumeBoiled == other.VolumeBoiled &&
+		b.OriginalGravity == other.OriginalGravity && b.FinalGravity == other.FinalGravity &&
+		b.RecipeURL == other.RecipeURL && b.CreatedBy.ID == other.CreatedBy.ID &&
+		b.MaxTemperature == other.MaxTemperature && b.MinTemperature == other.MinTemperature &&
+		b.AverageTemperature == other.AverageTemperature &&
+		b.BrewedDate.Equal(other.BrewedDate) && b.BottledDate.Equal(other.BottledDate) &&
+		b.CreatedAt.Equal(other.CreatedAt) //&& b.UpdatedAt().Equal(other.UpdatedAt())
 }
 
 // Initializes and returns a new Batch instance
 func NewBatch(id int, name string, brewedDate, bottledDate time.Time, volumeBoiled, volumeInFermenter float64,
 	volumeUnits VolumeUnitType, originalGravity, finalGravity float64, createdBy User, createdAt, updatedAt time.Time,
 	brewNotes, tastingNotes string, recipeURL string) Batch {
-	return Batch{batch: batch{ID: id, Name: name, BrewedDate: brewedDate, BottledDate: bottledDate, VolumeBoiled: volumeBoiled,
+	return Batch{ID: id, Name: name, BrewedDate: brewedDate, BottledDate: bottledDate, VolumeBoiled: volumeBoiled,
 		VolumeInFermenter: volumeInFermenter, VolumeUnits: volumeUnits, CreatedBy: createdBy, CreatedAt: createdAt,
 		UpdatedAt: updatedAt, BrewNotes: brewNotes, TastingNotes: tastingNotes, RecipeURL: recipeURL,
-		OriginalGravity: originalGravity, FinalGravity: finalGravity}}
+		OriginalGravity: originalGravity, FinalGravity: finalGravity}
 }
 
 // Find a batch by exact match of attributes
@@ -161,7 +136,7 @@ func FindBatch(params map[string]interface{}, db *sqlx.DB) (*Batch, error) {
 // then an insert is performed, otherwise an update on the User matching that id.
 func SaveBatch(db *sqlx.DB, b Batch) (Batch, error) {
 	// TODO: TEST CASE
-	if b.ID() != 0 {
+	if b.ID != 0 {
 		return UpdateBatch(db, b)
 	} else {
 		return InsertBatch(db, b)
@@ -183,16 +158,17 @@ func InsertBatch(db *sqlx.DB, b Batch) (Batch, error) {
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW()) RETURNING id, created_at, updated_at`)
 	// TODO: Make the dates strings for sql to be happy
 	err := db.QueryRow(
-		query, b.CreatedBy().ID(), b.Name(), b.BrewNotes(), b.TastingNotes(), b.BrewedDate(), b.BottledDate(),
-		b.VolumeBoiled(), b.VolumeInFermenter(), b.VolumeUnits(), b.OriginalGravity(), b.FinalGravity(), b.RecipeURL(),
-		b.MaxTemperature(), b.MinTemperature(), b.AverageTemperature()).Scan(&batchId, &createdAt, &updatedAt)
+		query, b.CreatedBy.ID, b.Name, b.BrewNotes, b.TastingNotes, b.BrewedDate, b.BottledDate,
+		b.VolumeBoiled, b.VolumeInFermenter, b.VolumeUnits, b.OriginalGravity, b.FinalGravity, b.RecipeURL,
+		b.MaxTemperature, b.MinTemperature, b.AverageTemperature).Scan(&batchId, &createdAt, &updatedAt)
 	if err != nil {
 		return b, err
 	}
 
-	b.batch.ID = batchId
-	b.batch.CreatedAt = createdAt
-	b.batch.UpdatedAt = updatedAt
+	// TODO: Can I just assign these directly now in Scan()?
+	b.ID = batchId
+	b.CreatedAt = createdAt
+	b.UpdatedAt = updatedAt
 	return b, nil
 }
 
@@ -209,13 +185,13 @@ func UpdateBatch(db *sqlx.DB, b Batch) (Batch, error) {
 		original_gravity = ?, final_gravity = ?, recipe_url = ?, max_temperature = ?, min_temperature = ?,
 		average_temperature = ?, updated_at = NOW() WHERE id = ?) RETURNING updated_at`)
 	err := db.QueryRow(
-		query, b.CreatedBy().ID(), b.Name(), b.BrewNotes(), b.TastingNotes(), b.BrewedDate(), b.BottledDate(),
-		b.VolumeBoiled(), b.VolumeInFermenter(), b.VolumeUnits(), b.OriginalGravity(), b.FinalGravity(), b.RecipeURL(),
-		b.MaxTemperature(), b.MinTemperature(), b.AverageTemperature()).Scan(&updatedAt)
+		query, b.CreatedBy.ID, b.Name, b.BrewNotes, b.TastingNotes, b.BrewedDate, b.BottledDate,
+		b.VolumeBoiled, b.VolumeInFermenter, b.VolumeUnits, b.OriginalGravity, b.FinalGravity, b.RecipeURL,
+		b.MaxTemperature, b.MinTemperature, b.AverageTemperature).Scan(&updatedAt)
 	if err != nil {
 		return b, err
 	}
-	b.batch.UpdatedAt = updatedAt
+	b.UpdatedAt = updatedAt
 	return b, nil
 }
 
@@ -239,7 +215,7 @@ func BatchesForUser(db *sqlx.DB, u User, count *int, after *int) (*[]Batch, erro
 	q := `SELECT ` + strings.Trim(selectCols, ", ") + ` FROM batches b LEFT JOIN users u on u.id = b.created_by_user_id ` +
 		`WHERE created_by_user_id = ? `
 
-	queryArgs = append(queryArgs, u.ID())
+	queryArgs = append(queryArgs, u.ID)
 	if after != nil {
 		q = q + ` and id > ?`
 		queryArgs = append(queryArgs, *after)
@@ -256,7 +232,7 @@ func BatchesForUser(db *sqlx.DB, u User, count *int, after *int) (*[]Batch, erro
 	return &batches, err
 }
 
-type fermenter struct {
+type Fermenter struct {
 	// I could use name + user composite key for pk on these in the db, but I'm probably going to be lazy
 	// and take the standard ORM-ish route and use an int or uuid  Int for now.
 	ID            int
@@ -273,26 +249,11 @@ type fermenter struct {
 	UpdatedAt time.Time
 }
 
-type Fermenter struct {
-	fermenter
-}
-
-func (f Fermenter) ID() int                           { return f.fermenter.ID }
-func (f Fermenter) Name() string                      { return f.fermenter.Name }
-func (f Fermenter) Description() string               { return f.fermenter.Description }
-func (f Fermenter) VolumeUnits() VolumeUnitType       { return f.fermenter.VolumeUnits }
-func (f Fermenter) FermenterType() FermenterStyleType { return f.fermenter.FermenterType }
-func (f Fermenter) IsActive() bool                    { return f.fermenter.IsActive }
-func (f Fermenter) IsAvailable() bool                 { return f.fermenter.IsAvailable }
-func (f Fermenter) CreatedBy() User                   { return f.fermenter.CreatedBy }
-func (f Fermenter) CreatedAt() time.Time              { return f.fermenter.CreatedAt }
-func (f Fermenter) UpdatedAt() time.Time              { return f.fermenter.UpdatedAt }
-
 func NewFermenter(id int, name, description string, volume float64, volumeUnits VolumeUnitType,
 	fermenterType FermenterStyleType, isActive, isAvailable bool, createdBy User, createdAt, updatedAt time.Time) Fermenter {
-	return Fermenter{fermenter{ID: id, Name: name, Description: description, Volume: volume, VolumeUnits: volumeUnits,
+	return Fermenter{ID: id, Name: name, Description: description, Volume: volume, VolumeUnits: volumeUnits,
 		FermenterType: fermenterType, IsActive: isActive, IsAvailable: isAvailable, CreatedBy: createdBy,
-		CreatedAt: createdAt, UpdatedAt: updatedAt}}
+		CreatedAt: createdAt, UpdatedAt: updatedAt}
 }
 
 // possibly should live elsewhere
@@ -301,7 +262,7 @@ func NewFermenter(id int, name, description string, volume float64, volumeUnits 
 // can know, ideally.
 // TODO: This may also want extra metadata such as model or type?  That is probably
 // going too far for now, so keep it simple.
-type temperatureSensor struct {
+type TemperatureSensor struct {
 	ID        int
 	Name      string
 	CreatedBy User
@@ -310,31 +271,21 @@ type temperatureSensor struct {
 	UpdatedAt time.Time
 }
 
-type TemperatureSensor struct {
-	temperatureSensor
-}
-
-func (t TemperatureSensor) ID() int              { return t.temperatureSensor.ID }
-func (t TemperatureSensor) Name() string         { return t.temperatureSensor.Name }
-func (t TemperatureSensor) CreatedBy() User      { return t.temperatureSensor.CreatedBy }
-func (t TemperatureSensor) CreatedAt() time.Time { return t.temperatureSensor.CreatedAt }
-func (t TemperatureSensor) UpdatedAt() time.Time { return t.temperatureSensor.UpdatedAt }
-
 // Returns a new TemperatureSensor
 func NewTemperatureSensor(id int, name string, createdBy User, createdAt, updatedAt time.Time) TemperatureSensor {
-	return TemperatureSensor{temperatureSensor{ID: id, Name: name, CreatedBy: createdBy, CreatedAt: createdAt, UpdatedAt: updatedAt}}
+	return TemperatureSensor{ID: id, Name: name, CreatedBy: createdBy, CreatedAt: createdAt, UpdatedAt: updatedAt}
 }
 
 // A single recorded temperature measurement from a temperatureSensor
 // This may get some tweaking to play nicely with data stored in Postgres or Influxdb
-type temperatureMeasurement struct {
-	ID           string // use a uuid
-	Temperature  float64
-	Units        TemperatureUnitType
-	TimeRecorded time.Time // when the measurement was recorded
-	Batch        Batch
-	TemperatureSensor  TemperatureSensor
-	Fermenter    Fermenter
+type TemperatureMeasurement struct {
+	ID                string // use a uuid
+	Temperature       float64
+	Units             TemperatureUnitType
+	TimeRecorded      time.Time // when the measurement was recorded
+	Batch             Batch
+	TemperatureSensor TemperatureSensor
+	Fermenter         Fermenter
 
 	// not sure createdBy is a useful name in this case vs just `user` but its consistent
 	CreatedBy User
@@ -344,24 +295,9 @@ type temperatureMeasurement struct {
 	UpdatedAt time.Time
 }
 
-type TemperatureMeasurement struct {
-	temperatureMeasurement
-}
-
-func (t TemperatureMeasurement) ID() string                 { return t.temperatureMeasurement.ID }
-func (t TemperatureMeasurement) Temperature() float64       { return t.temperatureMeasurement.Temperature }
-func (t TemperatureMeasurement) Units() TemperatureUnitType { return t.temperatureMeasurement.Units }
-func (t TemperatureMeasurement) TimeRecorded() time.Time    { return t.temperatureMeasurement.TimeRecorded }
-func (t TemperatureMeasurement) Batch() Batch               { return t.temperatureMeasurement.Batch }
-func (t TemperatureMeasurement) TemperatureSensor() TemperatureSensor   { return t.temperatureMeasurement.TemperatureSensor }
-func (t TemperatureMeasurement) Fermenter() Fermenter       { return t.temperatureMeasurement.Fermenter }
-func (t TemperatureMeasurement) CreatedBy() User            { return t.temperatureMeasurement.CreatedBy }
-func (t TemperatureMeasurement) CreatedAt() time.Time       { return t.temperatureMeasurement.CreatedAt }
-func (t TemperatureMeasurement) UpdatedAt() time.Time       { return t.temperatureMeasurement.UpdatedAt }
-
 func NewTemperatureMeasurement(id string, temperature float64, units TemperatureUnitType, batch Batch,
 	temperatureSensor TemperatureSensor, fermenter Fermenter, timeRecorded, createdAt, updatedAt time.Time, createdBy User) TemperatureMeasurement {
-	return TemperatureMeasurement{temperatureMeasurement{ID: id, Temperature: temperature, Units: units, Batch: batch,
+	return TemperatureMeasurement{ID: id, Temperature: temperature, Units: units, Batch: batch,
 		TemperatureSensor: temperatureSensor, Fermenter: fermenter, TimeRecorded: timeRecorded, CreatedAt: createdAt,
-		UpdatedAt: updatedAt, CreatedBy: createdBy}}
+		UpdatedAt: updatedAt, CreatedBy: createdBy}
 }

--- a/worrywort/batch_test.go
+++ b/worrywort/batch_test.go
@@ -15,10 +15,10 @@ func TestNewBatch(t *testing.T) {
 	bottledDate := brewedDate.Add(time.Duration(10) * time.Minute)
 	u := NewUser(1, "user@example.com", "Justin", "Michalicek", time.Now(), time.Now())
 
-	expectedBatch := Batch{batch: batch{ID: 1, Name: "Testing", BrewedDate: brewedDate, BottledDate: bottledDate, VolumeBoiled: 5,
+	expectedBatch := Batch{ID: 1, Name: "Testing", BrewedDate: brewedDate, BottledDate: bottledDate, VolumeBoiled: 5,
 		VolumeInFermenter: 4.5, VolumeUnits: GALLON, OriginalGravity: 1.060, FinalGravity: 1.020, CreatedBy: u,
 		CreatedAt: createdAt, UpdatedAt: updatedAt, BrewNotes: "Brew notes", TastingNotes: "Taste notes",
-		RecipeURL: "http://example.org/beer"}}
+		RecipeURL: "http://example.org/beer"}
 	b := NewBatch(1, "Testing", brewedDate, bottledDate, 5, 4.5, GALLON, 1.060, 1.020, u, createdAt, updatedAt,
 		"Brew notes", "Taste notes", "http://example.org/beer")
 
@@ -32,8 +32,8 @@ func TestNewFermenter(t *testing.T) {
 	createdAt := time.Now()
 	updatedAt := time.Now()
 	u := NewUser(1, "user@example.com", "Justin", "Michalicek", time.Now(), time.Now())
-	expected := Fermenter{fermenter{ID: 1, Name: "Ferm", Description: "A Fermenter", Volume: 5.0, VolumeUnits: GALLON,
-		FermenterType: BUCKET, IsActive: true, IsAvailable: true, CreatedBy: u, CreatedAt: createdAt, UpdatedAt: updatedAt}}
+	expected := Fermenter{ID: 1, Name: "Ferm", Description: "A Fermenter", Volume: 5.0, VolumeUnits: GALLON,
+		FermenterType: BUCKET, IsActive: true, IsAvailable: true, CreatedBy: u, CreatedAt: createdAt, UpdatedAt: updatedAt}
 
 	f := NewFermenter(1, "Ferm", "A Fermenter", 5.0, GALLON, BUCKET, true, true, u, createdAt, updatedAt)
 
@@ -46,7 +46,7 @@ func TestNewTemperatureSensor(t *testing.T) {
 	createdAt := time.Now()
 	updatedAt := time.Now()
 	u := NewUser(1, "user@example.com", "Justin", "Michalicek", time.Now(), time.Now())
-	expected := TemperatureSensor{temperatureSensor: temperatureSensor{ID: 1, Name: "Therm1", CreatedBy: u, CreatedAt: createdAt, UpdatedAt: updatedAt}}
+	expected := TemperatureSensor{ID: 1, Name: "Therm1", CreatedBy: u, CreatedAt: createdAt, UpdatedAt: updatedAt}
 
 	therm := NewTemperatureSensor(1, "Therm1", u, createdAt, updatedAt)
 
@@ -66,9 +66,9 @@ func TestNewTemperatureMeasurement(t *testing.T) {
 	createdAt := time.Now()
 	updatedAt := time.Now()
 	timeRecorded := time.Now()
-	expected := TemperatureMeasurement{temperatureMeasurement{ID: "shouldbeauuid", Temperature: 64.26, Units: FAHRENHEIT,
+	expected := TemperatureMeasurement{ID: "shouldbeauuid", Temperature: 64.26, Units: FAHRENHEIT,
 		TimeRecorded: timeRecorded, Batch: b, TemperatureSensor: therm, Fermenter: f, CreatedBy: u, CreatedAt: createdAt,
-		UpdatedAt: updatedAt}}
+		UpdatedAt: updatedAt}
 
 	m := NewTemperatureMeasurement(
 		"shouldbeauuid", 64.26, FAHRENHEIT, b, therm, f, timeRecorded, createdAt, updatedAt, u)
@@ -110,8 +110,8 @@ func TestFindBatch(t *testing.T) {
 	}
 
 	batchArgs := make(map[string]interface{})
-	batchArgs["created_by_user_id"] = u.ID()
-	batchArgs["id"] = b.ID()
+	batchArgs["created_by_user_id"] = u.ID
+	batchArgs["id"] = b.ID
 	found, err := FindBatch(batchArgs, db)
 	if err != nil {
 		t.Errorf("Got unexpected error: %s", err)
@@ -182,7 +182,7 @@ func TestBatchesForUser(t *testing.T) {
 	// May be worth trying this instead of spew, which has a Diff() function which may tell me what the difference is
 	// https://godoc.org/github.com/kr/pretty
 	expected := []Batch{b, b2}
-	if len(*batches) != 2 || expected[0].ID() != (*batches)[0].ID() || expected[1].ID() != (*batches)[1].ID() {
+	if len(*batches) != 2 || expected[0].ID != (*batches)[0].ID || expected[1].ID != (*batches)[1].ID {
 		t.Fatalf("Expected: %s\nGot: %s", spew.Sdump(expected[0]), spew.Sdump((*batches)[0]))
 	}
 	// TODO: Cannot figure out WHY these are not equal.

--- a/worrywort/user_test.go
+++ b/worrywort/user_test.go
@@ -12,8 +12,8 @@ func TestNewUser(t *testing.T) {
 	updatedAt := time.Now()
 	u := NewUser(1, "user@example.com", "Justin", "Michalicek", createdAt, updatedAt)
 
-	expectedUser := User{user{ID: 1, Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek",
-		CreatedAt: createdAt, UpdatedAt: updatedAt}}
+	expectedUser := User{ID: 1, Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek",
+		CreatedAt: createdAt, UpdatedAt: updatedAt}
 	if u != expectedUser {
 		t.Errorf("Expected:\n\n%v\n\nGot:\n\n%v", expectedUser, u)
 	}
@@ -23,54 +23,6 @@ func TestUserStruct(t *testing.T) {
 	createdAt := time.Now()
 	updatedAt := time.Now().Add(time.Hour * time.Duration(1))
 	u := NewUser(1, "user@example.com", "Justin", "Michalicek", createdAt, updatedAt)
-
-	t.Run("ID()", func(t *testing.T) {
-		var actual int = u.ID()
-		expected := u.user.ID
-		if actual != expected {
-			t.Errorf("Expected: %v, got: %v", expected, actual)
-		}
-	})
-
-	t.Run("LastName()", func(t *testing.T) {
-		var actual string = u.LastName()
-		expected := u.user.LastName
-		if actual != expected {
-			t.Errorf("Expected: %v, got: %v", expected, actual)
-		}
-	})
-
-	t.Run("FirstName()", func(t *testing.T) {
-		var actual string = u.FirstName()
-		expected := u.user.FirstName
-		if actual != expected {
-			t.Errorf("Expected: %v, got: %v", expected, actual)
-		}
-	})
-
-	t.Run("Email()", func(t *testing.T) {
-		var actual string = u.Email()
-		expected := u.user.Email
-		if actual != expected {
-			t.Errorf("Expected: %v, got: %v", expected, actual)
-		}
-	})
-
-	t.Run("CreatedAt()", func(t *testing.T) {
-		var actual time.Time = u.CreatedAt()
-		expected := u.user.CreatedAt
-		if actual != expected {
-			t.Errorf("Expected: %v, got: %v", expected, actual)
-		}
-	})
-
-	t.Run("UpdatedAt()", func(t *testing.T) {
-		var actual time.Time = u.UpdatedAt()
-		expected := u.user.UpdatedAt
-		if actual != expected {
-			t.Errorf("Expected: %v, got: %v", expected, actual)
-		}
-	})
 
 	t.Run("SetUserPassword()", func(t *testing.T) {
 		password := "password"
@@ -82,7 +34,7 @@ func TestUserStruct(t *testing.T) {
 			t.Errorf("Unexpected error hashing password: %v", err)
 		}
 
-		if bcrypt.CompareHashAndPassword([]byte(updatedUser.Password()), []byte(password)) != nil {
+		if bcrypt.CompareHashAndPassword([]byte(updatedUser.Password), []byte(password)) != nil {
 			t.Errorf("SetUserPassword() did not hash and set the password as expected")
 		}
 	})
@@ -111,7 +63,7 @@ func TestUserDatabaseFunctionality(t *testing.T) {
 	//func TestLookupUser(t *testing.T) {
 	t.Run("TestLookupUser", func(t *testing.T) {
 		t.Run("Test valid user id returns user", func(t *testing.T) {
-			actual, err := LookupUser(user.ID(), db)
+			actual, err := LookupUser(user.ID, db)
 
 			if err != nil {
 				t.Errorf("LookupUser() returned error %v", err)
@@ -188,7 +140,7 @@ func TestUserDatabaseFunctionality(t *testing.T) {
 	//func TestAuthenticateLogin(t *testing.T) {
 	t.Run("TestAuthenticateLogin", func(t *testing.T) {
 		t.Run("Test valid username and password returns User", func(t *testing.T) {
-			u, err := AuthenticateLogin(user.Email(), password, db)
+			u, err := AuthenticateLogin(user.Email, password, db)
 			if err != nil {
 				t.Errorf("Got unexpected error: %v", err)
 			}
@@ -199,7 +151,7 @@ func TestUserDatabaseFunctionality(t *testing.T) {
 		})
 
 		t.Run("Test valid username and password mistmatch returns error and empty User{}", func(t *testing.T) {
-			u, err := AuthenticateLogin(user.Email(), "a", db)
+			u, err := AuthenticateLogin(user.Email, "a", db)
 			if err != bcrypt.ErrMismatchedHashAndPassword {
 				t.Errorf("Expected error: %v\nGot: %v", UserNotFoundError, err)
 			}


### PR DESCRIPTION
* This immutable stuff is not how any other major go packages are
written.  Scrapping this idea and writing more idiomatic go.  The
immutable stuff mostly adds code and complexity with no clear gain at
this point.

Removing all of the private user, batch, etc which had public User,
Batch, etc with receivers hiding the real data.