### PR TITLE
User auth code cleanup

### DIFF
--- a/_dev_seeds/seed.sql
+++ b/_dev_seeds/seed.sql
@@ -15,3 +15,5 @@ INSERT INTO fermentors (id, user_id, name, description, volume, volume_units, fe
 
 INSERT INTO sensors (id, user_id, name, description, updated_at)
   VALUES (1, 1, 'Seed Sensor 1', 'Initial sensor from dev seed', now()) ON CONFLICT DO NOTHING;
+
+-- add some measurements and associations

--- a/authMiddleware/login_required.go
+++ b/authMiddleware/login_required.go
@@ -1,7 +1,6 @@
 package authMiddleware
 
 import (
-	"github.com/jmichalicek/worrywort-server-go/worrywort"
 	"net/http"
 )
 
@@ -13,7 +12,9 @@ func NewLoginRequiredHandler() func(http.Handler) http.Handler {
 			u, _ := UserFromContext(ctx)
 			// only update context if user is not already populated.
 			// what if it was ok, but user is an empty User{}?
-			if (worrywort.User{}) == u {
+			// nil user means that user has not been able to be authenticated yet. This will generally be
+			// the last middleware to run
+			if u == nil {
 				// http.StatusUnauthorized == 403
 				http.Error(rw, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 				return

--- a/authMiddleware/tokenAuth_test.go
+++ b/authMiddleware/tokenAuth_test.go
@@ -2,6 +2,7 @@ package authMiddleware
 
 import (
 	"context"
+	"github.com/google/go-cmp/cmp"
 	"github.com/jmichalicek/worrywort-server-go/worrywort"
 	"net/http"
 	"net/http/httptest"
@@ -54,17 +55,17 @@ func TestTokenMiddleware(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/", nil)
 		req.Header.Set("Authorization", "token 12345")
 		ctx := req.Context()
-		ctx = context.WithValue(ctx, DefaultUserKey, u)
+		ctx = context.WithValue(ctx, DefaultUserKey, &u)
 		req = req.WithContext(ctx)
 
 		// Handler which errors is wrong user is in context
 		handler := tokenAuthHandler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			ctx := req.Context()
-			ctxUser, ok := ctx.Value("user").(worrywort.User)
+			ctxUser, ok := ctx.Value("user").(*worrywort.User)
 			if !ok {
 				t.Errorf("Error getting user %v as worrywort.User", ctxUser)
 			}
-			if u != ctxUser {
+			if !cmp.Equal(&u, ctxUser) {
 				t.Errorf("Got %v but expected %v", ctxUser, u)
 			}
 			rw.WriteHeader(http.StatusOK)

--- a/graphqlApi/batch.go
+++ b/graphqlApi/batch.go
@@ -170,6 +170,9 @@ func (r *Resolver) CreateBatch(ctx context.Context, args *struct {
 	Input *createBatchInput
 }) (*createBatchPayload, error) {
 	u, _ := authMiddleware.UserFromContext(ctx)
+	if u == nil {
+		return nil, ErrUserNotAuthenticated
+	}
 
 	var inputPtr *createBatchInput = args.Input
 	var input createBatchInput = *inputPtr

--- a/worrywort/sensor.go
+++ b/worrywort/sensor.go
@@ -24,8 +24,6 @@ type Sensor struct {
 
 func buildSensorsQuery(params map[string]interface{}, db *sqlx.DB) *sqrl.SelectBuilder {
 	query := sqrl.Select().From("sensors s")
-	fmt.Printf("\nGOT ARGS: %#v\n\n", params)
-
 	for _, k := range []string{"id", "user_id", "uuid"} {
 		// TODO: return error if not ok?
 		if v, ok := params[k]; ok {


### PR DESCRIPTION
* Renamed errors to match go naming conventions
* Removed several lines of extra, unneccesary checks on data and just
return the user, whatever it may be, from AuthenticateLogin() even if
error
* Added new AuthenticateUserByToken() which returns AuthToken to replace LookupUserByToken()
* Made login() mutation accessible all the time again
* Moved validation of authenticated user to root resolvers instead of
middleware
* Made user in context be pointer so that it can be nil if user is not
authenticated