### PR TITLE
change Uuid to UUID

### DIFF
--- a/graphqlApi/batch.go
+++ b/graphqlApi/batch.go
@@ -20,7 +20,7 @@ type batchResolver struct {
 
 func (r *batchResolver) ID() graphql.ID {
 	if r.b != nil {
-		return graphql.ID(r.b.Uuid)
+		return graphql.ID(r.b.UUID)
 	} else {
 		log.Printf("Resolved batch with no id: %v", spew.Sdump(r))
 		return graphql.ID("")

--- a/graphqlApi/fermentor.go
+++ b/graphqlApi/fermentor.go
@@ -16,7 +16,7 @@ type fermentorResolver struct {
 
 func (r *fermentorResolver) ID() graphql.ID {
 	if r.f != nil {
-		return graphql.ID(r.f.Uuid)
+		return graphql.ID(r.f.UUID)
 	} else {
 		log.Printf("Nil Id on fermentor: %v", spew.Sdump(r))
 		return graphql.ID("")

--- a/graphqlApi/graphql_test.go
+++ b/graphqlApi/graphql_test.go
@@ -215,7 +215,7 @@ func TestCurrentUserQuery(t *testing.T) {
 		ctx := context.WithValue(ctx, authMiddleware.DefaultUserKey, &u)
 		result := worrywortSchema.Exec(ctx, query, operationName, nil)
 		var expected interface{}
-		err = json.Unmarshal([]byte(fmt.Sprintf(`{"currentUser": {"__typename": "User", "id": "%s"}}`, u.Uuid)), &expected)
+		err = json.Unmarshal([]byte(fmt.Sprintf(`{"currentUser": {"__typename": "User", "id": "%s"}}`, u.UUID)), &expected)
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
@@ -298,7 +298,7 @@ func TestBatchQuery(t *testing.T) {
 
 	t.Run("Test query for batch(id: ID!) which exists returns the batch", func(t *testing.T) {
 		variables := map[string]interface{}{
-			"id": b.Uuid,
+			"id": b.UUID,
 		}
 		query := `
 			query getBatch($id: ID!) {
@@ -312,7 +312,7 @@ func TestBatchQuery(t *testing.T) {
 		result := worrywortSchema.Exec(ctx, query, operationName, variables)
 
 		var expected interface{}
-		err := json.Unmarshal([]byte(fmt.Sprintf(`{"batch": {"__typename": "Batch", "id": "%s"}}`, b.Uuid)), &expected)
+		err := json.Unmarshal([]byte(fmt.Sprintf(`{"batch": {"__typename": "Batch", "id": "%s"}}`, b.UUID)), &expected)
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
@@ -330,9 +330,9 @@ func TestBatchQuery(t *testing.T) {
 	})
 
 	t.Run("Test query for batch(id: ID!) which does not exist returns null", func(t *testing.T) {
-		badUuid := uuid.New().String()
+		badUUID := uuid.New().String()
 		variables := map[string]interface{}{
-			"id": badUuid,
+			"id": badUUID,
 		}
 		query := `
 			query getBatch($id: ID!) {
@@ -353,7 +353,7 @@ func TestBatchQuery(t *testing.T) {
 	t.Run("Unauthenticated batch() returns null", func(t *testing.T) {
 		ctx := context.WithValue(ctx, authMiddleware.DefaultUserKey, nil)
 		variables := map[string]interface{}{
-			"id": b.Uuid,
+			"id": b.UUID,
 		}
 		query := `
 			query getBatch($id: ID!) {
@@ -393,15 +393,15 @@ func TestBatchQuery(t *testing.T) {
 		{
 			Name:      "Batches()",
 			Variables: map[string]interface{}{},
-			Expected:  []byte(fmt.Sprintf(response_2, after0cursor, b.Uuid, after1cursor, b2.Uuid))},
+			Expected:  []byte(fmt.Sprintf(response_2, after0cursor, b.UUID, after1cursor, b2.UUID))},
 		{
 			Name:      "Batches(first: 1)",
 			Variables: map[string]interface{}{"first": 1},
-			Expected:  []byte(fmt.Sprintf(response_1, "true", "false", after0cursor, b.Uuid))},
+			Expected:  []byte(fmt.Sprintf(response_1, "true", "false", after0cursor, b.UUID))},
 		{
 			Name:      "Batches(after: FIRST_CURSOR)",
 			Variables: map[string]interface{}{"after": after0cursor},
-			Expected:  []byte(fmt.Sprintf(response_1, "false", "false", after1cursor, b2.Uuid))},
+			Expected:  []byte(fmt.Sprintf(response_1, "false", "false", after1cursor, b2.UUID))},
 	}
 
 	for _, qt := range testargs {
@@ -652,7 +652,7 @@ func TestSensorQuery(t *testing.T) {
 
 	t.Run("Test query for sensor(id: ID!) which exists returns the sensor", func(t *testing.T) {
 		variables := map[string]interface{}{
-			"id": sensor1.Uuid,
+			"id": sensor1.UUID,
 		}
 		query := `
 			query getSensor($id: ID!) {
@@ -666,7 +666,7 @@ func TestSensorQuery(t *testing.T) {
 		result := worrywortSchema.Exec(ctx, query, operationName, variables)
 
 		var expected interface{}
-		err := json.Unmarshal([]byte(fmt.Sprintf(`{"sensor": {"__typename": "Sensor", "id": "%s"}}`, sensor1.Uuid)), &expected)
+		err := json.Unmarshal([]byte(fmt.Sprintf(`{"sensor": {"__typename": "Sensor", "id": "%s"}}`, sensor1.UUID)), &expected)
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
@@ -724,9 +724,9 @@ func TestSensorQuery(t *testing.T) {
 						PageInfo: pageInfo{false, false},
 						Edges: []edge{
 							edge{Typename: "SensorEdge", Cursor: encodedOffset1,
-								Node: node{Typename: "Sensor", Id: sensor1.Uuid}},
+								Node: node{Typename: "Sensor", Id: sensor1.UUID}},
 							edge{Typename: "SensorEdge", Cursor: encodedOffset2,
-								Node: node{Typename: "Sensor", Id: sensor2.Uuid},
+								Node: node{Typename: "Sensor", Id: sensor2.UUID},
 							},
 						},
 					},
@@ -740,7 +740,7 @@ func TestSensorQuery(t *testing.T) {
 						PageInfo: pageInfo{HasNextPage: true, HasPreviousPage: false},
 						Edges: []edge{
 							edge{Typename: "SensorEdge", Cursor: encodedOffset1,
-								Node: node{Typename: "Sensor", Id: sensor1.Uuid}},
+								Node: node{Typename: "Sensor", Id: sensor1.UUID}},
 						},
 					},
 				},
@@ -752,7 +752,7 @@ func TestSensorQuery(t *testing.T) {
 						PageInfo: pageInfo{false, false},
 						Edges: []edge{
 							edge{Typename: "SensorEdge", Cursor: encodedOffset2,
-								Node: node{Typename: "Sensor", Id: sensor2.Uuid}},
+								Node: node{Typename: "Sensor", Id: sensor2.UUID}},
 						},
 					},
 				},
@@ -1057,7 +1057,7 @@ func TestAssociateSensorToBatchMutation(t *testing.T) {
 		defer cleanAssociations()
 		variables := map[string]interface{}{
 			"input": map[string]interface{}{
-				"batchId":     batch.Uuid,
+				"batchId":     batch.UUID,
 				"sensorId":    strconv.Itoa(int(*sensor.Id)),
 				"description": "It is associated",
 			},
@@ -1105,7 +1105,7 @@ func TestAssociateSensorToBatchMutation(t *testing.T) {
 		}
 		variables := map[string]interface{}{
 			"input": map[string]interface{}{
-				"batchId":     batch.Uuid,
+				"batchId":     batch.UUID,
 				"sensorId":    strconv.Itoa(int(*sensor.Id)),
 				"description": "It is associated",
 			},
@@ -1141,7 +1141,7 @@ func TestAssociateSensorToBatchMutation(t *testing.T) {
 
 		variables := map[string]interface{}{
 			"input": map[string]interface{}{
-				"batchId":     batch.Uuid,
+				"batchId":     batch.UUID,
 				"sensorId":    strconv.Itoa(int(*sensor.Id)),
 				"description": "It is associated",
 			},
@@ -1166,7 +1166,7 @@ func TestAssociateSensorToBatchMutation(t *testing.T) {
 		defer cleanAssociations()
 		variables := map[string]interface{}{
 			"input": map[string]interface{}{
-				"batchId":     batch2.Uuid,
+				"batchId":     batch2.UUID,
 				"sensorId":    strconv.Itoa(int(*sensor.Id)),
 				"description": "It is associated",
 			},
@@ -1191,7 +1191,7 @@ func TestAssociateSensorToBatchMutation(t *testing.T) {
 		defer cleanAssociations()
 		variables := map[string]interface{}{
 			"input": map[string]interface{}{
-				"batchId":     batch.Uuid,
+				"batchId":     batch.UUID,
 				"sensorId":    strconv.Itoa(int(*sensor2.Id)),
 				"description": "It is associated",
 			},
@@ -1217,7 +1217,7 @@ func TestAssociateSensorToBatchMutation(t *testing.T) {
 		defer cleanAssociations()
 		variables := map[string]interface{}{
 			"input": map[string]interface{}{
-				"batchId":     batch.Uuid,
+				"batchId":     batch.UUID,
 				"sensorId":    strconv.Itoa(int(*sensor2.Id)),
 				"description": "It is associated",
 			},
@@ -1580,7 +1580,7 @@ func TestBatchSensorAssociationsQuery(t *testing.T) {
 				assoc2cursor, assoc2.Id))},
 		{
 			Name:      "BatchSensorAssociation(batchId: BATCH_1_ID)",
-			Variables: map[string]interface{}{"batchId": batch.Uuid},
+			Variables: map[string]interface{}{"batchId": batch.UUID},
 			Expected: []byte(fmt.Sprintf(
 				`{"batchSensorAssociations": {
 				  "__typename":"BatchSensorAssociationConnection",
@@ -1591,7 +1591,7 @@ func TestBatchSensorAssociationsQuery(t *testing.T) {
 				assoc1cursor, assoc1.Id))},
 		{
 			Name:      "BatchSensorAssociation(sensorId: SENSOR2_ID)",
-			Variables: map[string]interface{}{"sensorId": sensor2.Uuid},
+			Variables: map[string]interface{}{"sensorId": sensor2.UUID},
 			Expected: []byte(fmt.Sprintf(
 				`{"batchSensorAssociations": {
 				  "__typename":"BatchSensorAssociationConnection",
@@ -1763,7 +1763,7 @@ func TestTemperatureMeasurementsQuery(t *testing.T) {
 				},
 			},
 		},
-		{"temperatureMeasurements(batchId: <batch1>)", map[string]interface{}{"batchId": b.Uuid},
+		{"temperatureMeasurements(batchId: <batch1>)", map[string]interface{}{"batchId": b.UUID},
 			tmResponse{
 				temperatureMeasurementsConnection{
 					Typename: "TemperatureMeasurementConnection",
@@ -1775,7 +1775,7 @@ func TestTemperatureMeasurementsQuery(t *testing.T) {
 				},
 			},
 		},
-		{"temperatureMeasurements(sensorId: <s1.Uuid>)", map[string]interface{}{"sensorId": s1.Uuid},
+		{"temperatureMeasurements(sensorId: <s1.UUID>)", map[string]interface{}{"sensorId": s1.UUID},
 			tmResponse{
 				temperatureMeasurementsConnection{
 					Typename: "TemperatureMeasurementConnection",

--- a/graphqlApi/resolvers_test.go
+++ b/graphqlApi/resolvers_test.go
@@ -41,7 +41,7 @@ func makeTestBatch(u worrywort.User, attachUser bool) worrywort.Batch {
 	b := worrywort.Batch{Name: "Testing", BrewedDate: addMinutes(time.Now(), 1), BottledDate: addMinutes(time.Now(), 10),
 		VolumeBoiled: 5, VolumeInFermentor: 4.5, VolumeUnits: worrywort.GALLON, OriginalGravity: 1.060, FinalGravity: 1.020,
 		UserId: u.Id, BrewNotes: "Brew notes", TastingNotes: "Taste notes", RecipeURL: "http://example.org/beer",
-		Uuid: uuid.New().String()}
+		UUID: uuid.New().String()}
 	if attachUser {
 		b.CreatedBy = &u
 	}
@@ -58,13 +58,13 @@ func TestUserResolver(t *testing.T) {
 	createdAt := time.Now()
 	updatedAt := time.Now()
 	uid := int64(1)
-	u := worrywort.User{Id: &uid, Uuid: uuid.New().String(), Email: "user@example.com", FirstName: "Justin",
+	u := worrywort.User{Id: &uid, UUID: uuid.New().String(), Email: "user@example.com", FirstName: "Justin",
 		LastName: "Michalicek", CreatedAt: createdAt, UpdatedAt: updatedAt}
 	r := userResolver{u: &u}
 
 	t.Run("ID()", func(t *testing.T) {
 		var ID graphql.ID = r.ID()
-		expected := graphql.ID(u.Uuid)
+		expected := graphql.ID(u.UUID)
 		if ID != expected {
 			t.Errorf("Expected: %v, got: %v", expected, ID)
 		}
@@ -136,7 +136,7 @@ func TestBatchResolver(t *testing.T) {
 
 	t.Run("ID()", func(t *testing.T) {
 		var ID graphql.ID = br.ID()
-		expected := graphql.ID(brewed.Uuid)
+		expected := graphql.ID(brewed.UUID)
 		if ID != expected {
 			t.Errorf("Expected: %v, got: %v", expected, ID)
 		}
@@ -323,12 +323,12 @@ func TestFermentorResolver(t *testing.T) {
 	fId := int64(1)
 	f := worrywort.Fermentor{Id: &fId, CreatedAt: time.Now(), UpdatedAt: time.Now(), Name: "Ferm", Description: "A Fermentor", Volume: 5.0, VolumeUnits: worrywort.GALLON,
 		FermentorType: worrywort.BUCKET, IsActive: true, IsAvailable: true, CreatedBy: &u, UserId: u.Id,
-		Uuid: uuid.New().String()}
+		UUID: uuid.New().String()}
 	r := fermentorResolver{f: &f}
 
 	t.Run("ID()", func(t *testing.T) {
 		var ID graphql.ID = r.ID()
-		expected := graphql.ID(f.Uuid)
+		expected := graphql.ID(f.UUID)
 		if ID != expected {
 			t.Errorf("Expected: %v, got: %v", expected, ID)
 		}
@@ -389,12 +389,12 @@ func TestSensorResolver(t *testing.T) {
 
 	sId := int64(1)
 	sensor := worrywort.Sensor{Id: &sId, Name: "Therm1", UserId: u.Id, CreatedBy: &u, CreatedAt: time.Now(),
-		UpdatedAt: time.Now(), Uuid: uuid.New().String()}
+		UpdatedAt: time.Now(), UUID: uuid.New().String()}
 	r := sensorResolver{s: &sensor}
 
 	t.Run("ID()", func(t *testing.T) {
 		var ID graphql.ID = r.ID()
-		expected := graphql.ID(sensor.Uuid)
+		expected := graphql.ID(sensor.UUID)
 		if ID != expected {
 			t.Errorf("Expected: %v, got: %v", expected, ID)
 		}

--- a/graphqlApi/root_resolvers.go
+++ b/graphqlApi/root_resolvers.go
@@ -266,8 +266,8 @@ func (r *Resolver) Sensor(ctx context.Context, args struct{ ID graphql.ID }) (*s
 			log.Printf("%v", err)
 		}
 		return nil, nil // maybe error should be returned
-	} else if sensor != nil && sensor.Uuid != "" {
-		// TODO: check for Uuid is a hack because I need to rework FindSensor to return nil
+	} else if sensor != nil && sensor.UUID != "" {
+		// TODO: check for UUID is a hack because I need to rework FindSensor to return nil
 		// if it did not find a sensor
 		resolved = &sensorResolver{s: sensor}
 	} else {

--- a/graphqlApi/temperature_sensor.go
+++ b/graphqlApi/temperature_sensor.go
@@ -20,7 +20,7 @@ func (r *sensorResolver) ID() graphql.ID {
 		log.Printf("sensor resolver with nil id: %s", spew.Sdump(r))
 		return graphql.ID("")
 	}
-	return graphql.ID(r.s.Uuid)
+	return graphql.ID(r.s.UUID)
 }
 func (r *sensorResolver) CreatedAt() string { return dateString(r.s.CreatedAt) }
 func (r *sensorResolver) UpdatedAt() string { return dateString(r.s.UpdatedAt) }

--- a/graphqlApi/user.go
+++ b/graphqlApi/user.go
@@ -16,7 +16,7 @@ func (r *userResolver) ID() graphql.ID {
 		log.Printf("user resolver with nil user: %s", spew.Sdump(r))
 		return graphql.ID("")
 	} else {
-		return graphql.ID(r.u.Uuid)
+		return graphql.ID(r.u.UUID)
 	}
 }
 func (r *userResolver) FirstName() string { return r.u.FirstName }

--- a/worrywort/batch.go
+++ b/worrywort/batch.go
@@ -35,7 +35,7 @@ var TypeError error = errors.New("Invalid type specified")
 
 type Batch struct {
 	Id                *int64         `db:"id"`
-	Uuid              string         `db:"uuid"`
+	UUID              string         `db:"uuid"`
 	CreatedBy         *User          `db:"created_by,prefix=u"` // TODO: think I will change this to User
 	UserId            *int64         `db:"user_id"`
 	Name              string         `db:"name"`
@@ -163,7 +163,7 @@ func InsertBatch(db *sqlx.DB, b *Batch) error {
 	var updatedAt time.Time
 	var createdAt time.Time
 	batchId := new(int64)
-	batchUuid := new(string)
+	batchUUID := new(string)
 
 	// TODO: use sqrl
 	query := db.Rebind(`INSERT INTO batches (user_id, name, brew_notes, tasting_notes, brewed_date, bottled_date,
@@ -174,7 +174,7 @@ func InsertBatch(db *sqlx.DB, b *Batch) error {
 	err := db.QueryRow(
 		query, b.UserId, b.Name, b.BrewNotes, b.TastingNotes, b.BrewedDate, b.BottledDate,
 		b.VolumeBoiled, b.VolumeInFermentor, b.VolumeUnits, b.OriginalGravity, b.FinalGravity, b.RecipeURL,
-		b.MaxTemperature, b.MinTemperature, b.AverageTemperature).Scan(batchId, &createdAt, &updatedAt, batchUuid)
+		b.MaxTemperature, b.MinTemperature, b.AverageTemperature).Scan(batchId, &createdAt, &updatedAt, batchUUID)
 
 	if err == nil {
 		// TODO: double check to verify we get utc updated_at and created_at both this way and if just using "NOW()"
@@ -182,7 +182,7 @@ func InsertBatch(db *sqlx.DB, b *Batch) error {
 		b.Id = batchId
 		b.CreatedAt = createdAt
 		b.UpdatedAt = updatedAt
-		b.Uuid = *batchUuid
+		b.UUID = *batchUUID
 	}
 	return err
 }

--- a/worrywort/batch_test.go
+++ b/worrywort/batch_test.go
@@ -125,7 +125,7 @@ func TestFindSensorFuncs(t *testing.T) {
 			// This is ok for now, but really don't want to write one test per potential filter as those grow
 			// will at least add user uuid probably.
 			{"by id", map[string]interface{}{"id": *sensor.Id}, &sensor},
-			{"by uuid", map[string]interface{}{"uuid": sensor.Uuid}, &sensor},
+			{"by uuid", map[string]interface{}{"uuid": sensor.UUID}, &sensor},
 			// pagination
 			// TODO: test multiple filters?
 			// TODO: test errors - ie. something which could return multiple? Something which does not exist
@@ -157,7 +157,7 @@ func TestFindSensorFuncs(t *testing.T) {
 			// will at least add user uuid probably.
 			{"No Params", map[string]interface{}{}, []*Sensor{&sensor, &sensor2, &sensor3}},
 			{"by id", map[string]interface{}{"id": *sensor.Id}, []*Sensor{&sensor}},
-			{"by uuid", map[string]interface{}{"uuid": sensor2.Uuid}, []*Sensor{&sensor2}},
+			{"by uuid", map[string]interface{}{"uuid": sensor2.UUID}, []*Sensor{&sensor2}},
 			{"by user_id", map[string]interface{}{"user_id": *u.Id}, []*Sensor{&sensor, &sensor2}},
 			// pagination
 			{"Paginated no offset", map[string]interface{}{"limit": 1}, []*Sensor{&sensor}},
@@ -490,7 +490,7 @@ func TestFindBatches(t *testing.T) {
 		// will at least add user uuid probably.
 		{"Unfiltered", map[string]interface{}{}, []*Batch{&b, &b2, &u2batch}},
 		{"By batch.Id", map[string]interface{}{"id": *b.Id}, []*Batch{&b}},
-		{"By batch.Uuid", map[string]interface{}{"uuid": b.Uuid}, []*Batch{&b}},
+		{"By batch.UUID", map[string]interface{}{"uuid": b.UUID}, []*Batch{&b}},
 		{"By batch.user_id", map[string]interface{}{"user_id": *u2.Id}, []*Batch{&u2batch}},
 		// pagination
 		{"Paginated no offset", map[string]interface{}{"limit": 1}, []*Batch{&b}},
@@ -551,8 +551,8 @@ func TestBatch(t *testing.T) {
 			t.Errorf("Save() on new batch did not set CreatedAt")
 		}
 
-		if b.Uuid == "" {
-			t.Errorf("Save() on new batch did not set Uuid")
+		if b.UUID == "" {
+			t.Errorf("Save() on new batch did not set UUID")
 		}
 
 		batchArgs := make(map[string]interface{})
@@ -856,9 +856,9 @@ func TestFindTemperatureMeasurements(t *testing.T) {
 		{"Unfiltered", map[string]interface{}{}, []*TemperatureMeasurement{&m1, &m2, &m3}},
 		{"By m1.Id", map[string]interface{}{"id": m1.Id}, []*TemperatureMeasurement{&m1}},
 		{"By sensor_Id", map[string]interface{}{"sensor_id": *s1.Id}, []*TemperatureMeasurement{&m1, &m2}},
-		{"By sensor_uuid", map[string]interface{}{"sensor_uuid": s1.Uuid}, []*TemperatureMeasurement{&m1, &m2}},
+		{"By sensor_uuid", map[string]interface{}{"sensor_uuid": s1.UUID}, []*TemperatureMeasurement{&m1, &m2}},
 		{"By m3.UserId", map[string]interface{}{"user_id": *u2.Id}, []*TemperatureMeasurement{&m3}},
-		{"By batch_uuid with active sensor association", map[string]interface{}{"batch_uuid": b.Uuid}, []*TemperatureMeasurement{&m2}},
+		{"By batch_uuid with active sensor association", map[string]interface{}{"batch_uuid": b.UUID}, []*TemperatureMeasurement{&m2}},
 		// todo: add a batch_uuid test validating if the measurement is AFTER the disassociation
 		// pagination
 		{"Paginated no offset", map[string]interface{}{"limit": 1}, []*TemperatureMeasurement{&m1}},

--- a/worrywort/fermentor.go
+++ b/worrywort/fermentor.go
@@ -20,7 +20,7 @@ type Fermentor struct {
 	// I could use name + user composite key for pk on these in the db, but I'm probably going to be lazy
 	// and take the standard ORM-ish route and use an int or uuid  Int for now.
 	Id            *int64             `db:"id"`
-	Uuid          string             `db:"uuid"`
+	UUID          string             `db:"uuid"`
 	Name          string             `db:"name"`
 	Description   string             `db:"description"`
 	Volume        float64            `db:"volume"`

--- a/worrywort/sensor.go
+++ b/worrywort/sensor.go
@@ -13,7 +13,7 @@ import (
 // going too far for now, so keep it simple.
 type Sensor struct {
 	Id        *int64 `db:"id"`
-	Uuid      string `db:"uuid"`
+	UUID      string `db:"uuid"`
 	Name      string `db:"name"`
 	CreatedBy *User  `db:"u"`
 	UserId    *int64 `db:"user_id"`
@@ -100,7 +100,7 @@ func InsertSensor(db *sqlx.DB, t *Sensor) error {
 	if err == nil {
 		// TODO: Can I just assign these directly now in Scan()?
 		t.Id = sensorId
-		t.Uuid = *_uuid
+		t.UUID = *_uuid
 		t.CreatedAt = createdAt
 		t.UpdatedAt = updatedAt
 	}

--- a/worrywort/user.go
+++ b/worrywort/user.go
@@ -23,7 +23,7 @@ type User struct {
 	// really could use email as the pk for the db, but fudging it because I've been trained by ORMs
 	// TODO: Considering having a separate username from the email
 	Id        *int64 `db:"id"`
-	Uuid      string `db:"uuid"`
+	UUID      string `db:"uuid"`
 	FirstName string `db:"first_name"`
 	LastName  string `db:"last_name"`
 	Email     string `db:"email"`
@@ -83,7 +83,7 @@ func InsertUser(db *sqlx.DB, u *User) error {
 	}
 
 	u.Id = userId
-	u.Uuid = *guid
+	u.UUID = *guid
 	u.CreatedAt = createdAt
 	u.UpdatedAt = updatedAt
 	return nil


### PR DESCRIPTION
Change Uuid to UUID. Leaving Id as it is for now. ID is common as people are used to writing it like that and some golang ORMs expect it all caps, but technically should be Id per go naming conventions and that fits with FooId, etc.
Technically UUID should probably then be UUId but no one does that.