### PR TITLE
Better structure and names for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ mutation logIn($username: String!, $password: String!) {
 
 ### Roadmap:
 
-* improve core worrywortd server code a bit to be more testable
+#### Features
 * graphql user registration flow and supporting bits
 * graphql user management - password reset, update profile stuff, etc.
 * graphql fleshed out - several things need to be able to be updated, etc.
@@ -71,7 +71,12 @@ mutation logIn($username: String!, $password: String!) {
 * support for manual temperature readings
 * support for sensor associated with multiple batches - ambient air in a room or chamber, etc.
 * integration with tilt sensor
+
+
+#### Code
+* better/cleaner joins in sql - probably reusable functions to generate joins, column selects, etc. so that updates to columns do not need to happen in several places
 * nice way of handling/distributing migrations?
+* improve core worrywortd server code a bit to be more testable - main Server struct which has the routes, router, etc.
 
 
 ### Maybe TODO:

--- a/_dev_seeds/seed.sql
+++ b/_dev_seeds/seed.sql
@@ -1,6 +1,6 @@
 /* Create a fake user with the password 'password' */
-INSERT INTO users (id, first_name, last_name, email, password, is_active, is_admin, updated_at)
-  VALUES (1, 'First', 'Last', 'user@example.org', '$2a$13$ziIoEVxTifUjLqxgQr6p/OyVlfKqdET9m/t5rDEzXmRcaJNjPCINW', 't', 'f', now())
+INSERT INTO users (id, full_name, username, email, password, is_active, is_admin, updated_at)
+  VALUES (1, 'First McLast', 'worrywort', 'user@example.org', '$2a$13$ziIoEVxTifUjLqxgQr6p/OyVlfKqdET9m/t5rDEzXmRcaJNjPCINW', 't', 'f', now())
   ON CONFLICT DO NOTHING;
 
 INSERT INTO batches (id, user_id, name, tasting_notes, brewed_date, bottled_date, volume_boiled, volume_in_fermentor, volume_units, original_gravity, final_gravity, updated_at)

--- a/_migrations/0001_initial_db.up.sql
+++ b/_migrations/0001_initial_db.up.sql
@@ -3,6 +3,7 @@
 
 -- May need to do this for generating the uuid... but may already be loaded?
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE EXTENSION IF NOT EXISTS citext;
 
 BEGIN;
 -- id for PK because I'm lazy and so used to standard ORM rules
@@ -16,17 +17,18 @@ BEGIN;
 CREATE TABLE IF NOT EXISTS users(
   id BIGSERIAL PRIMARY KEY,
   uuid uuid DEFAULT gen_random_uuid(),
-  first_name text DEFAULT '',
-  last_name text DEFAULT '',
-  email text DEFAULT '',
+  full_name text DEFAULT '',
+  username citext DEFAULT '',
+  email citext DEFAULT '',
   password text DEFAULT '',
   is_active boolean DEFAULT FALSE,
   is_admin boolean DEFAULT FALSE,
 
   created_at timestamp with time zone DEFAULT now(),
-  updated_at timestamp with time zone
+  updated_at timestamp with time zone,
+  UNIQUE(email),
+  UNIQUE(username)
 );
-CREATE INDEX IF NOT EXISTS users_email_lower_idx ON users ((lower(email)));
 CREATE INDEX IF NOT EXISTS users_uuid_idx ON users (uuid);
 
 CREATE TABLE IF NOT EXISTS user_authtokens(

--- a/graphql_api/graphql_test.go
+++ b/graphql_api/graphql_test.go
@@ -111,7 +111,7 @@ func TestLoginMutation(t *testing.T) {
 	defer db.Close()
 
 	var worrywortSchema = graphql.MustParseSchema(graphql_api.Schema, graphql_api.NewResolver(db))
-	user := worrywort.User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	user := worrywort.User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	// This is the hash for the password `password`
 	// var hashedPassword string = "$2a$13$pPg7mwPA.VFf3W9AUZyMGO0Q2nhoh/979F/TZ8ED.iqVubLe.TDmi"
 	err = worrywort.SetUserPassword(&user, "password", bcrypt.MinCost)
@@ -163,7 +163,7 @@ func TestLoginMutation(t *testing.T) {
 		newToken := worrywort.AuthToken{}
 		query = db.Rebind(
 			`SELECT t.id, t.token, t.scope, t.expires_at, t.created_at, t.updated_at, u.id "user.id", u.uuid "user.uuid",
-				u.first_name "user.first_name", u.last_name "user.last_name", u.email "user.email",
+				u.full_name "user.full_name", u.username "user.username", u.email "user.email",
 				u.created_at "user.created_at", u.updated_at "user.updated_at", u.password "user.password"
 			 FROM user_authtokens t
 			 INNER JOIN users u ON t.user_id = u.id
@@ -192,7 +192,7 @@ func TestCurrentUserQuery(t *testing.T) {
 	}
 	defer db.Close()
 
-	u := worrywort.User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u := worrywort.User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = u.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
@@ -258,13 +258,13 @@ func TestBatchQuery(t *testing.T) {
 	}
 	defer db.Close()
 
-	u := worrywort.User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u := worrywort.User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = u.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
 	}
 
-	u2 := worrywort.User{Email: "user2@example.com", FirstName: "Justin", LastName: "M"}
+	u2 := worrywort.User{Email: "user2@example.com", FullName: "Justin D Michalicek", Username: "worrywort2"}
 	err = u2.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
@@ -477,7 +477,7 @@ func TestCreateTemperatureMeasurementMutation(t *testing.T) {
 	}
 	defer db.Close()
 
-	u := worrywort.User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u := worrywort.User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = u.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
@@ -488,7 +488,7 @@ func TestCreateTemperatureMeasurementMutation(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	u2 := worrywort.User{Email: "user2@example.com", FirstName: "Justin", LastName: "M"}
+	u2 := worrywort.User{Email: "user2@example.com", FullName: "Justin D Michalicek", Username: "worrywort2"}
 	if err = u2.Save(db); err != nil {
 		t.Fatalf("failed to insert user: %s", err)
 	}
@@ -609,7 +609,7 @@ func TestSensorQuery(t *testing.T) {
 	defer db.Close()
 
 	// TODO: This whole create 2 users and setup context is done A LOT here. can it be de-duplicated?
-	u := worrywort.User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u := worrywort.User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = u.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
@@ -619,7 +619,7 @@ func TestSensorQuery(t *testing.T) {
 	ctx = context.WithValue(ctx, "db", db)
 	ctx = context.WithValue(ctx, middleware.DefaultUserKey, &u)
 
-	u2 := worrywort.User{Email: "user2@example.com", FirstName: "Justin", LastName: "M"}
+	u2 := worrywort.User{Email: "user2@example.com", FullName: "Justin M", Username: "worrywort2"}
 	err = u2.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
@@ -838,7 +838,7 @@ func TestCreateBatchMutation(t *testing.T) {
 	}
 	defer db.Close()
 
-	u := worrywort.User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u := worrywort.User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = u.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
@@ -985,7 +985,7 @@ func TestAssociateSensorToBatchMutation(t *testing.T) {
 	}
 	defer db.Close()
 
-	u := worrywort.User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u := worrywort.User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = u.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
@@ -1001,7 +1001,7 @@ func TestAssociateSensorToBatchMutation(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	u2 := worrywort.User{Email: "user2@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u2 := worrywort.User{Email: "user2@example.com", FullName: "Justin Michalicek", Username: "worrywort2"}
 	if err := u2.Save(db); err != nil {
 		t.Fatalf("failed to insert user: %s", err)
 	}
@@ -1251,7 +1251,7 @@ func TestUpdateBatchSensorAssociationMutation(t *testing.T) {
 	}
 	defer db.Close()
 
-	u := worrywort.User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u := worrywort.User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = u.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
@@ -1267,7 +1267,7 @@ func TestUpdateBatchSensorAssociationMutation(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	u2 := worrywort.User{Email: "user2@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u2 := worrywort.User{Email: "user2@example.com", FullName: "Justin Michalicek", Username: "worrywort2"}
 	if err = u2.Save(db); err != nil {
 		t.Fatalf("failed to insert user: %s", err)
 	}
@@ -1486,7 +1486,7 @@ func TestBatchSensorAssociationsQuery(t *testing.T) {
 	}
 	defer db.Close()
 
-	u := worrywort.User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u := worrywort.User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = u.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
@@ -1636,13 +1636,13 @@ func TestTemperatureMeasurementsQuery(t *testing.T) {
 
 	// TODO: must be a good way to shorten this setup model creation... function which takes count of
 	// users to create, etc. I suppose.
-	u := worrywort.User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u := worrywort.User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = u.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
 	}
 
-	u2 := worrywort.User{Email: "user2@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u2 := worrywort.User{Email: "user2@example.com", FullName: "Justin Michalicek", Username: "worrywort2"}
 	err = u2.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
@@ -1830,7 +1830,7 @@ func TestCreateSensorMutation(t *testing.T) {
 	}
 	defer db.Close()
 
-	u := worrywort.User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u := worrywort.User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = u.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)

--- a/graphql_api/resolvers_test.go
+++ b/graphql_api/resolvers_test.go
@@ -59,8 +59,8 @@ func TestUserResolver(t *testing.T) {
 	createdAt := time.Now()
 	updatedAt := time.Now()
 	uid := int64(1)
-	u := worrywort.User{Id: &uid, UUID: uuid.New().String(), Email: "user@example.com", FirstName: "Justin",
-		LastName: "Michalicek", CreatedAt: createdAt, UpdatedAt: updatedAt}
+	u := worrywort.User{Id: &uid, UUID: uuid.New().String(), Email: "user@example.com", FullName: "Justin Michalicek",
+		Username: "worrywort", CreatedAt: createdAt, UpdatedAt: updatedAt}
 	r := userResolver{u: &u}
 
 	t.Run("ID()", func(t *testing.T) {
@@ -71,19 +71,19 @@ func TestUserResolver(t *testing.T) {
 		}
 	})
 
-	t.Run("FirstName()", func(t *testing.T) {
-		var firstName string = r.FirstName()
-		expected := "Justin"
+	t.Run("FullName()", func(t *testing.T) {
+		var firstName string = r.FullName()
+		expected := "Justin Michalicek"
 		if firstName != expected {
 			t.Errorf("Expected: %v, got: %v", expected, firstName)
 		}
 	})
 
-	t.Run("LastName()", func(t *testing.T) {
-		var lastName string = r.LastName()
-		expected := "Michalicek"
-		if lastName != expected {
-			t.Errorf("Expected: %v, got: %v", expected, lastName)
+	t.Run("Username()", func(t *testing.T) {
+		var username string = r.Username()
+		expected := "worrywort"
+		if username != expected {
+			t.Errorf("Expected: %v, got: %v", expected, username)
 		}
 	})
 
@@ -120,7 +120,7 @@ func TestBatchResolver(t *testing.T) {
 	}
 	defer db.Close()
 
-	u := worrywort.User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u := worrywort.User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = u.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
@@ -317,7 +317,7 @@ func TestFermentorResolver(t *testing.T) {
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, "db", db)
 
-	u := worrywort.User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u := worrywort.User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = u.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
@@ -383,7 +383,7 @@ func TestSensorResolver(t *testing.T) {
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, "db", db)
 
-	u := worrywort.User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u := worrywort.User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = u.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
@@ -453,7 +453,7 @@ func TestTemperatureMeasurementResolver(t *testing.T) {
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, "db", db)
 
-	u := worrywort.User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u := worrywort.User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = u.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
@@ -554,7 +554,8 @@ func TestTemperatureMeasurementResolver(t *testing.T) {
 
 func TestAuthTokenResolver(t *testing.T) {
 	uId := int64(1)
-	u := worrywort.User{Id: &uId, Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek", CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	u := worrywort.User{Id: &uId, Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort",
+		CreatedAt: time.Now(), UpdatedAt: time.Now()}
 
 	token := worrywort.NewToken("token", u, worrywort.TOKEN_SCOPE_ALL)
 	token.Id = "tokenid"
@@ -588,7 +589,7 @@ func TestBatchSensorAssociationResolver(t *testing.T) {
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, "db", db)
 
-	u := worrywort.User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u := worrywort.User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = u.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)

--- a/graphql_api/schema.go
+++ b/graphql_api/schema.go
@@ -183,8 +183,8 @@ var Schema = `
 
 	type User {
 		id: ID!
-		firstName: String!
-		lastName: String!
+		fullName: String!
+		username: String!
 		email: String!
 		createdAt: DateTime!
 		updatedAt: DateTime!

--- a/graphql_api/user.go
+++ b/graphql_api/user.go
@@ -21,8 +21,8 @@ func (r *userResolver) ID() graphql.ID {
 }
 
 // TODO: scrap first/last name... just store name. names are hard, not everyone has straight first and last.
-func (r *userResolver) FirstName() string   { return r.u.FirstName }
-func (r *userResolver) LastName() string    { return r.u.LastName }
+func (r *userResolver) FullName() string    { return r.u.FullName }
+func (r *userResolver) Username() string    { return r.u.Username }
 func (r *userResolver) Email() string       { return r.u.Email }
 func (r *userResolver) CreatedAt() DateTime { return DateTime{r.u.CreatedAt} }
 func (r *userResolver) UpdatedAt() DateTime { return DateTime{r.u.UpdatedAt} }

--- a/middleware/token_auth_test.go
+++ b/middleware/token_auth_test.go
@@ -13,8 +13,8 @@ import (
 func TestTokenMiddleware(t *testing.T) {
 	// Handler
 	uid := int64(1)
-	expectedUser := worrywort.User{Id: &uid, Email: "jmichalicek@gmail.com", FirstName: "Justin", LastName: "Michalicek",
-		CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	expectedUser := worrywort.User{Id: &uid, Email: "jmichalicek@gmail.com", FullName: "Justin Michalicek",
+		Username: "worrywort", CreatedAt: time.Now(), UpdatedAt: time.Now()}
 	getUser := func(token string) (*worrywort.User, error) { return &expectedUser, nil }
 	tokenAuthHandler := NewTokenAuthHandler(getUser)
 
@@ -50,7 +50,7 @@ func TestTokenMiddleware(t *testing.T) {
 		// If a user is already set, such as by a different auth middleware such as http basic or jwt
 		// then this middleware should not change that.
 		uid := int64(2)
-		u := worrywort.User{Id: &uid, Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+		u := worrywort.User{Id: &uid, Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 
 		req, _ := http.NewRequest("GET", "/", nil)
 		req.Header.Set("Authorization", "token 12345")

--- a/rest_api/restapi_test.go
+++ b/rest_api/restapi_test.go
@@ -85,7 +85,7 @@ func TestMeasurementSerializer(t *testing.T) {
 
 	// TODO: must be a good way to shorten this setup model creation... function which takes count of
 	// users to create, etc. I suppose.
-	user := worrywort.User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	user := worrywort.User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = user.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
@@ -182,7 +182,7 @@ func TestMeasurementHandler(t *testing.T) {
 
 	// TODO: must be a good way to shorten this setup model creation... function which takes count of
 	// users to create, etc. I suppose.
-	user := worrywort.User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	user := worrywort.User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = user.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)

--- a/worrywort/auth_token.go
+++ b/worrywort/auth_token.go
@@ -122,7 +122,7 @@ func AuthenticateUserByToken(tokenStr string, db *sqlx.DB) (AuthToken, error) {
 	// TODO: sqrl
 	query := db.Rebind(
 		`SELECT t.id, t.token, t.scope, t.expires_at, t.created_at, t.updated_at, u.id "user.id", u.uuid "user.uuid",
-			u.first_name "user.first_name", u.last_name "user.last_name", u.email "user.email", u.created_at "user.created_at",
+			u.full_name "user.full_name", u.username "user.username", u.email "user.email", u.created_at "user.created_at",
 			u.updated_at "user.updated_at", u.password "user.password" FROM user_authtokens t
 			JOIN users u ON t.user_id = u.id
 			WHERE t.id = ? AND (t.expires_at IS NULL OR t.expires_at > ?)`)

--- a/worrywort/batch_test.go
+++ b/worrywort/batch_test.go
@@ -37,7 +37,7 @@ func TestSaveFermentor(t *testing.T) {
 	}
 	defer db.Close()
 
-	u := User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u := User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = u.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
@@ -91,13 +91,13 @@ func TestFindSensorFuncs(t *testing.T) {
 	}
 	defer db.Close()
 
-	u := User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u := User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = u.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
 	}
 
-	u2 := User{Email: "user2@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u2 := User{Email: "user2@example.com", FullName: "Justin Michalicek", Username: "worrywort2"}
 	err = u2.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
@@ -190,7 +190,7 @@ func TestSaveSensor(t *testing.T) {
 	}
 	defer db.Close()
 
-	u := User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u := User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = u.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
@@ -247,7 +247,7 @@ func TestTemperatureMeasurementModel(t *testing.T) {
 	}
 	defer db.Close()
 
-	u := User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u := User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = u.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
@@ -398,7 +398,7 @@ func TestFindBatch(t *testing.T) {
 	}
 	defer db.Close()
 
-	u := User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u := User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = u.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
@@ -437,13 +437,13 @@ func TestFindBatches(t *testing.T) {
 	}
 	defer db.Close()
 
-	u := User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u := User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = u.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
 	}
 
-	u2 := User{Email: "user2@example.com", FirstName: "Justin", LastName: "M"}
+	u2 := User{Email: "user2@example.com", FullName: "Justin M", Username: "worrywort2"}
 	err = u2.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
@@ -523,7 +523,7 @@ func TestBatch(t *testing.T) {
 	}
 	defer db.Close()
 
-	u := User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u := User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = u.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
@@ -624,7 +624,7 @@ func TestBatchSensorAssociations(t *testing.T) {
 	}
 	defer db.Close()
 
-	u := User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u := User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = u.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
@@ -718,7 +718,7 @@ func TestFindBatchSensorAssociations(t *testing.T) {
 	}
 	defer db.Close()
 
-	u := User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u := User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = u.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
@@ -797,13 +797,13 @@ func TestFindTemperatureMeasurements(t *testing.T) {
 
 	// TODO: must be a good way to shorten this setup model creation... function which takes count of
 	// users to create, etc. I suppose.
-	u := User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u := User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	err = u.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)
 	}
 
-	u2 := User{Email: "user2@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	u2 := User{Email: "user2@example.com", FullName: "Justin Michalicek", Username: "worrywort2"}
 	err = u2.Save(db)
 	if err != nil {
 		t.Fatalf("failed to insert user: %s", err)

--- a/worrywort/sensor.go
+++ b/worrywort/sensor.go
@@ -39,7 +39,7 @@ func buildSensorsQuery(params map[string]interface{}, db *sqlx.DB) *sqrl.SelectB
 		query = query.Column(fmt.Sprintf("s.%s", k))
 	}
 
-	for _, k := range []string{"id", "uuid", "first_name", "last_name", "email", "password", "created_at", "updated_at"} {
+	for _, k := range []string{"id", "uuid", "full_name", "username", "email", "password", "created_at", "updated_at"} {
 		query = query.Column(fmt.Sprintf("u.%s \"u.%s\"", k, k))
 	}
 

--- a/worrywort/user_test.go
+++ b/worrywort/user_test.go
@@ -13,7 +13,7 @@ import (
 func TestUserStruct(t *testing.T) {
 	createdAt := time.Now()
 	updatedAt := time.Now().Add(time.Hour * time.Duration(1))
-	u := User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek", CreatedAt: createdAt,
+	u := User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort", CreatedAt: createdAt,
 		UpdatedAt: updatedAt}
 
 	t.Run("SetUserPassword()", func(t *testing.T) {
@@ -44,7 +44,7 @@ func TestUserDatabaseFunctionality(t *testing.T) {
 	}
 	defer db.Close()
 
-	user := User{Email: "user@example.com", FirstName: "Justin", LastName: "Michalicek"}
+	user := User{Email: "user@example.com", FullName: "Justin Michalicek", Username: "worrywort"}
 	password := "password"
 	err = SetUserPassword(&user, password, bcrypt.MinCost)
 	if err != nil {


### PR DESCRIPTION
* Just use full_name instead of first_name and last_name. Names come in
many forms.
* Add separate username which will likely be used later for display,
possibly for login, etc. rather than exposing users email addresses.